### PR TITLE
pytest-timeout 2.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-timeout" %}
-{% set version = "1.4.2" %}
-{% set hash = "20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76" %}
+{% set version = "2.0.1" %}
+{% set hash = "a5ec4eceddb8ea726911848593d668594107e797621e97f93a1d1dbc6fbb9080" %}
 {% set ext = "tar.gz" %}
 
 package:


### PR DESCRIPTION
Update pytest-timeout to 2.0.1