### PR TITLE
pytest-timeout 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-timeout" %}
-{% set version = "1.4.2" %}
-{% set hash = "20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76" %}
+{% set version = "2.0.2" %}
+{% set hash = "e6f98b54dafde8d70e4088467ff621260b641eb64895c4195b6e5c8f45638112" %}
 {% set ext = "tar.gz" %}
 
 package:


### PR DESCRIPTION
Update pytest-timeout to 2.0.2