### PR TITLE
Update `pytest-timeout` to version `2.1.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
     - pytest >=3.6.0
@@ -29,21 +30,24 @@ requirements:
 test:
   requires:
     - pytest
+    - pip
   imports:
     - pytest_timeout
   commands:
     - py.test --help
+    - pip check
 
 about:
   home: https://bitbucket.org/pytest-dev/pytest-timeout
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: This is a plugin which will terminate tests after a certain timeout.
   description: |
     pytest-timeout is a plugin which will terminate tests after a certain timeout.
     When doing so it will show a stack dump of all threads running at the time.
   doc_url: https://pypi.python.org/pypi/pytest-timeout
-  dev_url: https://bitbucket.org/pytest-dev/pytest-timeout
+  dev_url: https://github.com/pytest-dev/pytest-timeout
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-timeout" %}
-{% set version = "1.4.2" %}
-{% set hash = "20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76" %}
+{% set version = "2.1.0" %}
+{% set hash = "c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9" %}
 {% set ext = "tar.gz" %}
 
 package:


### PR DESCRIPTION

  `pytest-timeout` version `2.1.0`
  
1. - [x] check the upstream

    https://github.com/pytest-dev/pytest-timeout/tree/2.1.0

2. - [x] check the pinnings

    https://github.com/pytest-dev/pytest-timeout/blob/2.1.0/tox.ini

    https://github.com/pytest-dev/pytest-timeout/blob/2.1.0/test_pytest_timeout.py

    https://github.com/pytest-dev/pytest-timeout/blob/2.1.0/setup.py

3. - [x] check the changelogs

    https://github.com/pytest-dev/pytest-timeout/blob/2.1.0/README.rst#Changelog

    The changes mentioned in the changelog were mainly new features added. 

    - Get terminal width from shutil instead of deprecated py, thanks Andrew Svetlov.
    
    - Add an API for extending pytest-timeout functionality with third-party plugins, thanks Andrew Svetlov.

4. - [x] additional research

    https://github.com/conda-forge/pytest-timeout-feedstock/issues

    There are currently no open issues mentioned in `conda-forge`

5. - [x] verify dev_url

    The old `dev_url` seems to be deprecated

    The old `url` seems to be deprecated, the new url is available in `pypi.org`

    https://github.com/pytest-dev/pytest-timeout

6. - [x] verify doc_url

    https://pypi.python.org/pypi/pytest-timeout

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
10. - [x] verify setuptools
11. - [x] verify wheel
     `wheel` was added to the test section
12. - [x] pip in the test section
     `pip` was added to the test section
13. - [x] veriy the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `pytest-timeout` to version `2.1.0`

