### PR TITLE
update to 2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,49 @@
 {% set name = "pytest-timeout" %}
-{% set version = "1.4.2" %}
-{% set hash = "20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76" %}
-{% set ext = "tar.gz" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ ext }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ ext }}
-  sha256: {{ hash }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90
 
 build:
-  noarch: python
   number: 0
-  script: python -m pip install . --no-deps --ignore-installed
+  script: python -m pip install --no-deps --no-build-isolation --ignore-installed -vv .
 
 requirements:
   host:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
-    - pytest >=3.6.0
+    - pytest >=5.0.0
 
 test:
   requires:
     - pytest
+    - pip
   imports:
     - pytest_timeout
   commands:
+    - pip check
     - py.test --help
 
 about:
-  home: https://bitbucket.org/pytest-dev/pytest-timeout
+  home: https://github.com/pytest-dev/pytest-timeout
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: This is a plugin which will terminate tests after a certain timeout.
   description: |
     pytest-timeout is a plugin which will terminate tests after a certain timeout.
     When doing so it will show a stack dump of all threads running at the time.
-  doc_url: https://pypi.python.org/pypi/pytest-timeout
-  dev_url: https://bitbucket.org/pytest-dev/pytest-timeout
+  doc_url: https://github.com/pytest-dev/pytest-timeout
+  dev_url: https://github.com/pytest-dev/pytest-timeout
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
update to 2.2.0 required by featuretools tests
- clean up recipe
-  [upstream](https://github.com/pytest-dev/pytest-timeout/tree/2.2.0)
